### PR TITLE
Feat: 공통 응답 클래스 생성

### DIFF
--- a/src/main/java/com/calefit/common/base/BaseResponse.java
+++ b/src/main/java/com/calefit/common/base/BaseResponse.java
@@ -1,0 +1,17 @@
+package com.calefit.common.base;
+
+import lombok.Getter;
+
+@Getter
+public class BaseResponse<T> {
+
+    private final String code;
+    private final String message;
+    private final T data;
+
+    public BaseResponse(String code, String message, T data) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+}

--- a/src/main/java/com/calefit/common/base/BaseTime.java
+++ b/src/main/java/com/calefit/common/base/BaseTime.java
@@ -1,4 +1,4 @@
-package com.calefit.common.domain;
+package com.calefit.common.base;
 
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;

--- a/src/main/java/com/calefit/common/base/CodeAndMessage.java
+++ b/src/main/java/com/calefit/common/base/CodeAndMessage.java
@@ -1,0 +1,7 @@
+package com.calefit.common.base;
+
+public interface CodeAndMessage {
+
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/com/calefit/common/base/CodeAndMessages.java
+++ b/src/main/java/com/calefit/common/base/CodeAndMessages.java
@@ -1,6 +1,6 @@
 package com.calefit.common.base;
 
-public interface CodeAndMessage {
+public interface CodeAndMessages {
 
     String getCode();
     String getMessage();

--- a/src/main/java/com/calefit/common/base/ResponseCodeAndMessages.java
+++ b/src/main/java/com/calefit/common/base/ResponseCodeAndMessages.java
@@ -1,6 +1,9 @@
 package com.calefit.common.base;
 
-public class ResponseCodeAndMessages implements CodeAndMessage {
+public enum ResponseCodeAndMessages implements CodeAndMessages {
+
+    //Crew
+    CREW_MODIFY_SUCCESS("CMS","수정이 완료되었습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/calefit/common/base/ResponseCodeAndMessages.java
+++ b/src/main/java/com/calefit/common/base/ResponseCodeAndMessages.java
@@ -1,0 +1,22 @@
+package com.calefit.common.base;
+
+public class ResponseCodeAndMessages implements CodeAndMessage {
+
+    private final String code;
+    private final String message;
+
+    ResponseCodeAndMessages(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/calefit/common/entity/CommonResponseEntity.java
+++ b/src/main/java/com/calefit/common/entity/CommonResponseEntity.java
@@ -1,22 +1,22 @@
 package com.calefit.common.entity;
 
 import com.calefit.common.base.BaseResponse;
-import com.calefit.common.base.CodeAndMessage;
+import com.calefit.common.base.CodeAndMessages;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.MultiValueMap;
 
 public class CommonResponseEntity<T> extends ResponseEntity<BaseResponse<T>> {
 
-    public CommonResponseEntity(CodeAndMessage codeAndMessages, HttpStatus httpStatus) {
+    public CommonResponseEntity(CodeAndMessages codeAndMessages, HttpStatus httpStatus) {
         this(codeAndMessages, null, httpStatus);
     }
 
-    public CommonResponseEntity(CodeAndMessage codeAndMessages, T data, HttpStatus httpStatus) {
+    public CommonResponseEntity(CodeAndMessages codeAndMessages, T data, HttpStatus httpStatus) {
         this(codeAndMessages, data, null, httpStatus);
     }
 
-    public CommonResponseEntity(CodeAndMessage codeAndMessages, T data, MultiValueMap<String, String> headers, HttpStatus httpStatus) {
+    public CommonResponseEntity(CodeAndMessages codeAndMessages, T data, MultiValueMap<String, String> headers, HttpStatus httpStatus) {
         super(new BaseResponse<>(codeAndMessages.getCode(), codeAndMessages.getMessage(), data), headers, httpStatus);
     }
 }

--- a/src/main/java/com/calefit/common/entity/CommonResponseEntity.java
+++ b/src/main/java/com/calefit/common/entity/CommonResponseEntity.java
@@ -1,0 +1,22 @@
+package com.calefit.common.entity;
+
+import com.calefit.common.base.BaseResponse;
+import com.calefit.common.base.CodeAndMessage;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
+
+public class CommonResponseEntity<T> extends ResponseEntity<BaseResponse<T>> {
+
+    public CommonResponseEntity(CodeAndMessage codeAndMessages, HttpStatus httpStatus) {
+        this(codeAndMessages, null, httpStatus);
+    }
+
+    public CommonResponseEntity(CodeAndMessage codeAndMessages, T data, HttpStatus httpStatus) {
+        this(codeAndMessages, data, null, httpStatus);
+    }
+
+    public CommonResponseEntity(CodeAndMessage codeAndMessages, T data, MultiValueMap<String, String> headers, HttpStatus httpStatus) {
+        super(new BaseResponse<>(codeAndMessages.getCode(), codeAndMessages.getMessage(), data), headers, httpStatus);
+    }
+}


### PR DESCRIPTION
### ✔️이슈번호
  - Issue #16

### 📚작업목록
  - [x] CommonResponseEntity 작성
  - [x] 패키지 구성 수정

### 📖작업내용
  - 공통 응답 클래스 작성을 위해 필요한 클래스들을 생성

### 🙋‍♂️참고사항
  - ResponseCodeAndMessages Enum 클래스에 각자 맡은 API의 Message를 추가하면 됩니다.
