### PR TITLE
Chore: 도커 이미지 pull시 도커 로그인 코드 추가

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -123,6 +123,7 @@ jobs:
           script: |
             sudo docker ps -a -q --filter "name=calefit-test" | grep -q . && sudo docker stop calefit-test && sudo docker rm calefit-test | true
             sudo docker rmi ${{ secrets.DOCKER_USERNAME }}/calefit-test
+            sudo docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
             sudo docker pull ${{ secrets.DOCKER_USERNAME }}/calefit-test
             sudo docker run --add-host=host.docker.internal:host-gateway -d -p 80:8080 --name calefit-test ${{ secrets.DOCKER_USERNAME }}/calefit-test
             sudo docker rmi -f $(docker images -f "dangling=true" -q) || true


### PR DESCRIPTION
- 도커 레포 private으로 전환해서 로그인 필요

### ✔️이슈번호

### 📚작업목록
  - [x] CD workflow에 docker login 과정 추가

